### PR TITLE
Refresh MiniMax LiteLLM template with global endpoint, M2.7, and video input

### DIFF
--- a/litellm_config.yaml
+++ b/litellm_config.yaml
@@ -67,15 +67,25 @@ model_list:
 #     api_key: os.environ/MOONSHOT_API_KEY
 #     drop_params: true
 
-# MiniMax（截至 2026-07-17 的最新旗舰模型：MiniMax-M3）。设置 MINIMAX_API_KEY 后取消注释。
+# MiniMax（截至 2026-07-22 的最新模型：MiniMax-M3 与 MiniMax-M2.7）。设置 MINIMAX_API_KEY 后取消注释。
+# 全球区 OpenAI 兼容端点：https://api.minimax.io/v1 ；中国区 OpenAI 兼容端点：https://api.minimaxi.com/v1。
 # - model_name: MiniMax-M3
 #   model_info:
 #     mode: responses
 #     supports_vision: true
+#     supports_video_input: true
 #   litellm_params:
 #     model: minimax/MiniMax-M3
 #     api_key: os.environ/MINIMAX_API_KEY
-#     api_base: https://api.minimaxi.com/v1
+#     api_base: https://api.minimax.io/v1
+#     drop_params: true
+# - model_name: MiniMax-M2.7
+#   model_info:
+#     mode: responses
+#   litellm_params:
+#     model: minimax/MiniMax-M2.7
+#     api_key: os.environ/MINIMAX_API_KEY
+#     api_base: https://api.minimax.io/v1
 #     drop_params: true
 
 # DeepSeek（截至 2026-07-17 的最新旗舰模型：DeepSeek-V4-Pro）。设置 DEEPSEEK_API_KEY 后取消注释。


### PR DESCRIPTION
Reason: Refresh the LiteLLM MiniMax template to declare the global endpoint, MiniMax-M2.7, and MiniMax-M3 video input support.

## Changes
- Update the commented MiniMax block in `litellm_config.yaml`:
  - Switch the default `api_base` from the CN-only endpoint (`https://api.minimaxi.com/v1`) to the global endpoint (`https://api.minimax.io/v1`), and document both the global and CN OpenAI-compatible endpoints in the comment so users can pick the right region.
  - Add a `MiniMax-M2.7` model entry (text-only) alongside `MiniMax-M3`.
  - Declare `supports_video_input: true` on `MiniMax-M3` so its video input capability is reflected.

## Verification
- Confirmed the diff keeps the existing commented-config style and indentation consistent with the surrounding Kimi, DeepSeek, and Z.AI blocks.
- No executable tests exist for this commented template file; the change is a documentation/template refresh only.
