### PR TITLE
Add MiniMax Image Generation Skill

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-settings",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Reusable Codex skills and workflows from feiskyer/codex-settings.",
   "author": {
     "name": "feiskyer",

--- a/skills/minimax-image-skill/SKILL.md
+++ b/skills/minimax-image-skill/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: minimax-image-skill
+description: 'Generate images with the MiniMax Image API. Use when the user asks for MiniMax image generation, image-01, image-01-live, or an image from a text prompt through MiniMax.'
+---
+
+# MiniMax Image Skill
+
+Generate images from a text prompt through the bundled MiniMax Image API helper.
+
+## Resolve the skill directory
+
+Resolve the absolute directory containing this `SKILL.md` before running a command and refer to it as `<skill-dir>`. Keep output paths relative to the user's working directory unless the user requests another location.
+
+## Requirements
+
+- Export `MINIMAX_API_KEY` before running the helper.
+- Use Python 3.9 or newer. The helper uses only the Python standard library.
+
+## Generate an image
+
+Ask for the prompt and, when relevant, the model, region, aspect ratio, dimensions, result count, and output filename. Then run:
+
+```bash
+python3 "<skill-dir>/minimax_image.py" \
+  --prompt "A quiet observatory beneath an aurora" \
+  --output "observatory.png"
+```
+
+The global endpoint is used by default. Select the China endpoint explicitly when needed:
+
+```bash
+python3 "<skill-dir>/minimax_image.py" \
+  --region china \
+  --prompt "A paper-cut landscape at sunrise" \
+  --output "landscape.png"
+```
+
+Use `--model image-01-live` for that model. Optional API fields are exposed through `--aspect-ratio`, `--width`, `--height`, `--seed`, `--n`, `--response-format`, and `--disable-prompt-optimizer`.
+
+The helper downloads URL responses immediately because generated URLs expire. It also decodes base64 responses and creates output parent directories automatically. For multiple results, it adds a numeric suffix to the output filename.
+
+## Safety and failures
+
+- Never print or persist the API key.
+- Do not call the API until the prompt and local output path pass validation.
+- If the API rejects a field combination, report the returned error and ask the user to adjust only that option.
+- Do not claim success unless at least one image was saved locally.

--- a/skills/minimax-image-skill/agents/openai.yaml
+++ b/skills/minimax-image-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "MiniMax Image"
+  short_description: "Generate images from text with the MiniMax Image API"
+  default_prompt: "Use $minimax-image-skill to generate an image with MiniMax and save it locally."

--- a/skills/minimax-image-skill/minimax_image.py
+++ b/skills/minimax-image-skill/minimax_image.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Generate images from text with the MiniMax Image API."""
+
+import argparse
+import base64
+import binascii
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+API_ENDPOINTS = {
+    "global": "https://api.minimax.io/v1/image_generation",
+    "china": "https://api.minimaxi.com/v1/image_generation",
+}
+SUPPORTED_MODELS = ("image-01", "image-01-live")
+SUPPORTED_ASPECT_RATIOS = ("1:1", "16:9", "4:3", "3:2", "2:3", "3:4", "9:16", "21:9")
+DOWNLOAD_TIMEOUT_SECONDS = 60
+MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024
+
+
+def positive_int(value):
+    """Parse a positive integer for argparse."""
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def image_count(value):
+    """Parse the API's supported image count range."""
+    parsed = positive_int(value)
+    if parsed > 9:
+        raise argparse.ArgumentTypeError("must be between 1 and 9")
+    return parsed
+
+
+def image_dimension(value):
+    """Parse an image dimension accepted by the API."""
+    parsed = positive_int(value)
+    if parsed < 512 or parsed > 2048 or parsed % 8:
+        raise argparse.ArgumentTypeError(
+            "must be between 512 and 2048 and divisible by 8"
+        )
+    return parsed
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Generate images from text with the MiniMax Image API"
+    )
+    parser.add_argument("--prompt", required=True, help="Text prompt for image generation")
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output filename (default: minimax-image-<UUID>.png)",
+    )
+    parser.add_argument(
+        "--model",
+        choices=SUPPORTED_MODELS,
+        default="image-01",
+        help="Image model (default: image-01)",
+    )
+    parser.add_argument(
+        "--region",
+        choices=tuple(API_ENDPOINTS),
+        default="global",
+        help="API region (default: global)",
+    )
+    parser.add_argument(
+        "--aspect-ratio",
+        choices=SUPPORTED_ASPECT_RATIOS,
+        default=None,
+        help="Requested aspect ratio",
+    )
+    parser.add_argument("--width", type=image_dimension, default=None, help="Requested width")
+    parser.add_argument("--height", type=image_dimension, default=None, help="Requested height")
+    parser.add_argument("--seed", type=int, default=None, help="Generation seed")
+    parser.add_argument("--n", type=image_count, default=1, help="Number of images")
+    parser.add_argument(
+        "--response-format",
+        choices=("url", "base64"),
+        default="url",
+        help="API response format (default: url)",
+    )
+    parser.add_argument(
+        "--disable-prompt-optimizer",
+        action="store_true",
+        help="Disable prompt optimization",
+    )
+    return parser
+
+
+def parse_args(argv=None):
+    args = build_parser().parse_args(argv)
+    args.prompt = args.prompt.strip()
+    if not args.prompt:
+        build_parser().error("--prompt must not be empty")
+    if len(args.prompt) > 1500:
+        build_parser().error("--prompt must not exceed 1500 characters")
+    if (args.width is None) != (args.height is None):
+        build_parser().error("--width and --height must be provided together")
+    args.output = args.output or f"minimax-image-{uuid.uuid4()}.png"
+    output_path = Path(args.output).expanduser()
+    if output_path.name in {"", ".", ".."}:
+        build_parser().error("--output must name a file")
+    if output_path.is_dir():
+        build_parser().error("--output must not be a directory")
+    args.output = output_path
+    return args
+
+
+def build_payload(args):
+    payload = {
+        "model": args.model,
+        "prompt": args.prompt,
+        "response_format": args.response_format,
+        "n": args.n,
+        "prompt_optimizer": not args.disable_prompt_optimizer,
+    }
+    for field in ("aspect_ratio", "width", "height", "seed"):
+        value = getattr(args, field)
+        if value is not None:
+            payload[field] = value
+    return payload
+
+
+def read_response(response):
+    data = response.read(MAX_DOWNLOAD_BYTES + 1)
+    if len(data) > MAX_DOWNLOAD_BYTES:
+        raise RuntimeError("API response exceeds the maximum allowed size")
+    try:
+        return json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("MiniMax returned an invalid JSON response") from exc
+
+
+def response_count(metadata, field):
+    """Parse a non-negative image count from response metadata."""
+    value = metadata.get(field)
+    if isinstance(value, bool):
+        raise TypeError(f"MiniMax response contained an invalid {field}")
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(f"MiniMax response contained an invalid {field}") from exc
+    if parsed < 0:
+        raise RuntimeError(f"MiniMax response contained an invalid {field}")
+    return parsed
+
+
+def request_generation(args, api_key, opener=urlopen):
+    request = Request(
+        API_ENDPOINTS[args.region],
+        data=json.dumps(build_payload(args)).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with opener(request, timeout=DOWNLOAD_TIMEOUT_SECONDS) as response:
+            payload = read_response(response)
+    except HTTPError as exc:
+        raise RuntimeError(f"MiniMax request failed with HTTP {exc.code}") from exc
+    except URLError as exc:
+        raise RuntimeError(f"MiniMax request failed: {exc.reason}") from exc
+
+    base_response = payload.get("base_resp")
+    if isinstance(base_response, dict):
+        status_code = base_response.get("status_code")
+        if status_code not in (None, 0):
+            message = base_response.get("status_msg") or "unknown API error"
+            raise RuntimeError(f"MiniMax request failed: {message}")
+
+    data = payload.get("data")
+    image_values = data.get("image_urls") if isinstance(data, dict) else None
+    if not isinstance(image_values, list) or not image_values:
+        raise RuntimeError("MiniMax response did not contain any images")
+    if not all(isinstance(value, str) and value for value in image_values):
+        raise RuntimeError("MiniMax response contained an invalid image value")
+
+    metadata = payload.get("metadata")
+    if not isinstance(metadata, dict):
+        raise TypeError("MiniMax response did not contain image metadata")
+    success_count = response_count(metadata, "success_count")
+    response_count(metadata, "failed_count")
+    if success_count != len(image_values):
+        raise RuntimeError("MiniMax response image count did not match metadata")
+    return image_values
+
+
+def output_path_for_result(output_path, index, multiple):
+    if multiple:
+        return output_path.with_name(
+            f"{output_path.stem}_{index + 1}{output_path.suffix}"
+        )
+    return output_path
+
+
+def read_limited(response):
+    data = response.read(MAX_DOWNLOAD_BYTES + 1)
+    if len(data) > MAX_DOWNLOAD_BYTES:
+        raise RuntimeError("Downloaded image exceeds the maximum allowed size")
+    if not data:
+        raise RuntimeError("Downloaded image is empty")
+    return data
+
+
+def download_image(url, opener=urlopen):
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise RuntimeError("MiniMax returned an invalid image URL")
+    request = Request(url, headers={"Accept": "image/*"})
+    try:
+        with opener(request, timeout=DOWNLOAD_TIMEOUT_SECONDS) as response:
+            return read_limited(response)
+    except HTTPError as exc:
+        raise RuntimeError(f"Image download failed with HTTP {exc.code}") from exc
+    except URLError as exc:
+        raise RuntimeError(f"Image download failed: {exc.reason}") from exc
+
+
+def decode_image(value):
+    encoded = value.split(",", 1)[1] if value.startswith("data:") and "," in value else value
+    try:
+        data = base64.b64decode(encoded, validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise RuntimeError("MiniMax returned invalid base64 image data") from exc
+    if not data:
+        raise RuntimeError("MiniMax returned empty base64 image data")
+    if len(data) > MAX_DOWNLOAD_BYTES:
+        raise RuntimeError("Decoded image exceeds the maximum allowed size")
+    return data
+
+
+def save_images(image_values, output_path, response_format, opener=urlopen):
+    output_path = Path(output_path)
+    saved_paths = []
+    multiple = len(image_values) > 1
+    for index, value in enumerate(image_values):
+        target = output_path_for_result(output_path, index, multiple)
+        image_data = (
+            download_image(value, opener=opener)
+            if response_format == "url"
+            else decode_image(value)
+        )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(image_data)
+        saved_paths.append(str(target))
+    return saved_paths
+
+
+def run(args, api_key=None, api_opener=urlopen, download_opener=urlopen):
+    active_api_key = api_key or os.getenv("MINIMAX_API_KEY")
+    if not active_api_key:
+        raise RuntimeError("MINIMAX_API_KEY is required")
+    image_values = request_generation(args, active_api_key, opener=api_opener)
+    saved_paths = save_images(
+        image_values,
+        args.output,
+        args.response_format,
+        opener=download_opener,
+    )
+    for saved_path in saved_paths:
+        print(f"Image saved to: {saved_path}")
+    return saved_paths
+
+
+def main(argv=None):
+    try:
+        return 0 if run(parse_args(argv)) else 1
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/minimax-image-skill/tests/test_minimax_image.py
+++ b/skills/minimax-image-skill/tests/test_minimax_image.py
@@ -1,0 +1,225 @@
+import base64
+import importlib.util
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = SKILL_DIR / "minimax_image.py"
+SPEC = importlib.util.spec_from_file_location("minimax_image", MODULE_PATH)
+minimax_image = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(minimax_image)
+
+
+class FakeResponse:
+    def __init__(self, body):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, size=-1):
+        return self.body[:size] if size >= 0 else self.body
+
+
+class RecordingOpener:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def __call__(self, request, timeout):
+        self.calls.append((request, timeout))
+        return FakeResponse(self.responses.pop(0))
+
+
+class MiniMaxImageTests(unittest.TestCase):
+    def test_global_request_uses_configured_contract(self):
+        opener = RecordingOpener(
+            [
+                json.dumps(
+                    {
+                        "data": {"image_urls": ["aW1hZ2U="]},
+                        "metadata": {"success_count": "1", "failed_count": "0"},
+                        "base_resp": {"status_code": 0},
+                    }
+                ).encode()
+            ]
+        )
+        args = minimax_image.parse_args(
+            [
+                "--prompt",
+                "A quiet observatory",
+                "--model",
+                "image-01-live",
+                "--aspect-ratio",
+                "16:9",
+                "--response-format",
+                "base64",
+            ]
+        )
+
+        values = minimax_image.request_generation(args, "test-key", opener=opener)
+
+        request = opener.calls[0][0]
+        payload = json.loads(request.data)
+        self.assertEqual(request.full_url, "https://api.minimax.io/v1/image_generation")
+        self.assertEqual(request.headers["Authorization"], "Bearer test-key")
+        self.assertEqual(payload["model"], "image-01-live")
+        self.assertEqual(payload["prompt"], "A quiet observatory")
+        self.assertEqual(payload["aspect_ratio"], "16:9")
+        self.assertEqual(payload["response_format"], "base64")
+        self.assertEqual(values, ["aW1hZ2U="])
+
+    def test_dimensions_seed_and_optimizer_are_forwarded(self):
+        opener = RecordingOpener(
+            [
+                json.dumps(
+                    {
+                        "data": {"image_urls": ["aW1hZ2U="]},
+                        "metadata": {"success_count": 1, "failed_count": 0},
+                        "base_resp": {"status_code": 0},
+                    }
+                ).encode()
+            ]
+        )
+        args = minimax_image.parse_args(
+            [
+                "--prompt",
+                "A geometric garden",
+                "--width",
+                "1024",
+                "--height",
+                "768",
+                "--seed",
+                "42",
+                "--disable-prompt-optimizer",
+                "--response-format",
+                "base64",
+            ]
+        )
+
+        minimax_image.request_generation(args, "test-key", opener=opener)
+
+        payload = json.loads(opener.calls[0][0].data)
+        self.assertEqual(payload["width"], 1024)
+        self.assertEqual(payload["height"], 768)
+        self.assertEqual(payload["seed"], 42)
+        self.assertFalse(payload["prompt_optimizer"])
+
+    def test_invalid_paid_request_inputs_are_rejected_locally(self):
+        invalid_arguments = [
+            ["--prompt", "x" * 1501],
+            ["--prompt", "test", "--n", "10"],
+            ["--prompt", "test", "--width", "513", "--height", "512"],
+        ]
+        for arguments in invalid_arguments:
+            with (
+                self.subTest(arguments=arguments),
+                redirect_stderr(io.StringIO()),
+                self.assertRaises(SystemExit),
+            ):
+                minimax_image.parse_args(arguments)
+
+    def test_china_request_and_base64_response_are_saved(self):
+        api_opener = RecordingOpener(
+            [
+                json.dumps(
+                    {
+                        "data": {
+                            "image_urls": [
+                                base64.b64encode(b"first-image").decode(),
+                                base64.b64encode(b"second-image").decode(),
+                            ]
+                        },
+                        "metadata": {"success_count": 2, "failed_count": 0},
+                        "base_resp": {"status_code": 0},
+                    }
+                ).encode()
+            ]
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "nested" / "result.png"
+            args = minimax_image.parse_args(
+                [
+                    "--region",
+                    "china",
+                    "--prompt",
+                    "A paper-cut landscape",
+                    "--response-format",
+                    "base64",
+                    "--n",
+                    "2",
+                    "--output",
+                    str(output),
+                ]
+            )
+
+            saved = minimax_image.run(
+                args,
+                api_key="test-key",
+                api_opener=api_opener,
+            )
+
+            self.assertEqual(
+                api_opener.calls[0][0].full_url,
+                "https://api.minimaxi.com/v1/image_generation",
+            )
+            self.assertEqual(Path(saved[0]).read_bytes(), b"first-image")
+            self.assertEqual(Path(saved[1]).read_bytes(), b"second-image")
+
+    def test_url_response_is_downloaded(self):
+        downloader = RecordingOpener([b"downloaded-image"])
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "result.png"
+
+            saved = minimax_image.save_images(
+                ["https://cdn.example/result.png"],
+                output,
+                "url",
+                opener=downloader,
+            )
+
+            self.assertEqual(saved, [str(output)])
+            self.assertEqual(output.read_bytes(), b"downloaded-image")
+
+    def test_api_error_is_reported(self):
+        opener = RecordingOpener(
+            [
+                json.dumps(
+                    {"base_resp": {"status_code": 1001, "status_msg": "invalid request"}}
+                ).encode()
+            ]
+        )
+        args = minimax_image.parse_args(["--prompt", "A lighthouse"])
+
+        with self.assertRaisesRegex(RuntimeError, "invalid request"):
+            minimax_image.request_generation(args, "test-key", opener=opener)
+
+    def test_response_metadata_must_match_returned_images(self):
+        opener = RecordingOpener(
+            [
+                json.dumps(
+                    {
+                        "data": {"image_urls": ["aW1hZ2U="]},
+                        "metadata": {"success_count": 0, "failed_count": 1},
+                        "base_resp": {"status_code": 0},
+                    }
+                ).encode()
+            ]
+        )
+        args = minimax_image.parse_args(
+            ["--prompt", "A lighthouse", "--response-format", "base64"]
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "did not match metadata"):
+            minimax_image.request_generation(args, "test-key", opener=opener)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reason: Add the missing MiniMax text-to-image tool with regional endpoints and complete request and response handling.

## Changes

- Add a bundled `minimax-image-skill` with a standard-library command-line helper.
- Support the global and China image-generation endpoints, current models, documented request controls, URL downloads, and base64 output.
- Validate API status, image metadata, response counts, local inputs, downloads, and output paths before reporting success.
- Add offline request, response, validation, and output tests and bump the Plugin version to `1.2.0`.

## Checks

- `python3 -m json.tool .codex-plugin/plugin.json >/dev/null`
- `python3 ~/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py .`
- `python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/minimax-image-skill`
- `python3 -m compileall -q skills/minimax-image-skill`
- `uvx ruff check skills/minimax-image-skill`
- `python3 -m unittest discover -s skills/minimax-image-skill/tests -v`
- `bash scripts/test-plugin-install.sh`

The live API integration was not run because this change is covered by mocked offline tests and no real credential was used.
